### PR TITLE
adding support for composite swaggers.

### DIFF
--- a/ValidationTool.njsproj
+++ b/ValidationTool.njsproj
@@ -12,7 +12,7 @@
     <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{349c5851-65df-11da-9384-00065b846f21};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <ScriptArguments>example .\search\2015-02-28\swagger\searchindex.json --details</ScriptArguments>
+    <ScriptArguments>example https://github.com/Azure/azure-rest-api-specs/blob/master/insights/compositeInsightsClient.json</ScriptArguments>
     <StartWebBrowser>True</StartWebBrowser>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'" />

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "description": "Validate Azure REST API Specifications",
   "license": "MIT",
   "dependencies": {
+    "async": "^2.1.2",
     "glob": "^5.0.14",
     "json-schema-ref-parser": "^3.1.2",
     "lodash": "^3.10.1",


### PR DESCRIPTION
This PR will make it easy to validate composite swaggers. It will loop through the documents array and validate all the sub swagger specs.
For example:
```
node validate.js example https://github.com/Azure/azure-rest-api-specs/blob/master/insights/compositeInsightsClient.json
```