### PR TITLE
Correctly set json based Content-Type based on produces or consumes defined in swagger

### DIFF
--- a/lib/specValidator.js
+++ b/lib/specValidator.js
@@ -555,6 +555,10 @@ class SpecValidator {
       }
     }
 
+    if (!(options.headers['content-type'] || options.headers['Content-Type'])) {
+      options.headers['Content-Type'] = utils.getJsonContentType(operation.consumes);
+    }
+
     let request = null;
     let validationResult = {};
     if (!foundIssues) {
@@ -687,7 +691,7 @@ class SpecValidator {
       }
       //ensure content-type header is present
       if (!(exampleResponseHeaders['content-type'] || exampleResponseHeaders['Content-Type'])) {
-        exampleResponseHeaders['content-type'] = operation.produces[0];
+        exampleResponseHeaders['content-type'] = utils.getJsonContentType(operation.produces);
       }
       let exampleResponse = new ResponseWrapper(exampleResponseStatusCode, exampleResponseBody, exampleResponseHeaders);
       let validationResult = self.validateResponse(operation, exampleResponse);

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -361,3 +361,20 @@ exports.removeObject = function removeObject(doc, ptr) {
   }
   return result;
 };
+
+/*
+ * Finds the first content-type that contains "/json". Only supported Content-Types are 
+ * "text/json" & "application/json" so we perform first best match that contains '/json'
+ * @param {Array} Array of content-types.
+ * 
+ * @param {string} content-type that contains "/json".
+ */
+exports.getJsonContentType = function getJsonContentType(consumesOrProduces) {
+  var firstMatchedJson = null;
+  if (consumesOrProduces) {
+    firstMatchedJson = consumesOrProduces.find((contentType) => {
+      return (contentType.match(/.*\/json.*/ig) !== null);
+    });
+  }
+  return firstMatchedJson;
+};


### PR DESCRIPTION
Fixes https://github.com/Azure/openapi-validation-tools/issues/76

ms_rest need to be released for this fix. Respective PR https://github.com/Azure/azure-sdk-for-node/pull/2126